### PR TITLE
Modular Python scraper for e‑Pública contract data with pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# webscrap_test
-WebScrap for test do get public information from brazil gorvenment 
+# WebScrap Test - Contratos Públicos (Portal e-Pública)
+
+Aplicação Python para extrair dados de contratos no Portal da Transparência e-Pública, incluindo:
+
+- Valor total do contrato
+- Município
+- Unidade gestora
+- Responsáveis jurídicos
+- Gestores
+- Fiscais
+- Itens do contrato com paginação
+
+## Estrutura do projeto
+
+```text
+src/contracts_scraper/
+  domain/models.py            # Entidades de domínio (ContractData, ContractItem, ResponsiblePerson)
+  services/contract_scraper.py # Lógica de scraping e paginação
+  utils/config.py             # Leitura de app.properties
+  main.py                     # Ponto de entrada
+app.properties                # Configuração da URL e parâmetros da execução
+```
+
+## Configuração
+
+Edite `app.properties`:
+
+```ini
+[portal]
+contract_url = https://transparencia.e-publica.net/epublica-portal/#/palmeira/portal/compras/contratoView?params=%7B%22id%22:%22MV8yMDMy%22,%22mode%22:%22INFO%22%7D
+headless = true
+timeout_ms = 90000
+```
+
+## Execução
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python -m playwright install chromium
+PYTHONPATH=src python -m contracts_scraper.main
+```
+
+A saída será JSON no terminal com todos os dados coletados.
+
+## Observações
+
+- O portal é renderizado com JavaScript, por isso o scraper usa Playwright.
+- A paginação dos itens é tratada buscando o botão de próxima página na seção "Itens".
+- Caso o portal altere o HTML/seletores, ajuste os seletores em `services/contract_scraper.py`.

--- a/app.properties
+++ b/app.properties
@@ -1,0 +1,4 @@
+[portal]
+contract_url = https://transparencia.e-publica.net/epublica-portal/#/palmeira/portal/compras/contratoView?params=%7B%22id%22:%22MV8yMDMy%22,%22mode%22:%22INFO%22%7D
+headless = true
+timeout_ms = 90000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright==1.54.0

--- a/src/contracts_scraper/__init__.py
+++ b/src/contracts_scraper/__init__.py
@@ -1,0 +1,1 @@
+"""Contracts scraper package."""

--- a/src/contracts_scraper/domain/models.py
+++ b/src/contracts_scraper/domain/models.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, asdict, field
+from typing import List, Dict, Any
+
+
+@dataclass
+class ResponsiblePerson:
+    role: str
+    cpf: str
+    name: str
+    start_date: str
+    end_date: str
+
+
+@dataclass
+class ContractItem:
+    number: str
+    description: str
+    quantity: str
+    unit: str
+    unit_value_brl: str
+    total_value_brl: str
+
+
+@dataclass
+class ContractData:
+    contract_number: str = ""
+    total_value_brl: str = ""
+    municipality: str = ""
+    management_unit: str = ""
+    object_description: str = ""
+    legal_representatives: List[ResponsiblePerson] = field(default_factory=list)
+    managers: List[ResponsiblePerson] = field(default_factory=list)
+    inspectors: List[ResponsiblePerson] = field(default_factory=list)
+    items: List[ContractItem] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["legal_representatives"] = [asdict(x) for x in self.legal_representatives]
+        data["managers"] = [asdict(x) for x in self.managers]
+        data["inspectors"] = [asdict(x) for x in self.inspectors]
+        data["items"] = [asdict(x) for x in self.items]
+        return data

--- a/src/contracts_scraper/main.py
+++ b/src/contracts_scraper/main.py
@@ -1,0 +1,15 @@
+import json
+
+from contracts_scraper.services.contract_scraper import ContractScraperService
+from contracts_scraper.utils.config import AppConfig
+
+
+def main() -> None:
+    config = AppConfig("app.properties")
+    scraper = ContractScraperService(timeout_ms=config.timeout_ms)
+    contract_data = scraper.scrape_contract(config.contract_url, headless=config.headless)
+    print(json.dumps(contract_data.to_dict(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/contracts_scraper/services/contract_scraper.py
+++ b/src/contracts_scraper/services/contract_scraper.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import re
+from typing import List, Set
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, sync_playwright
+
+from contracts_scraper.domain.models import ContractData, ContractItem, ResponsiblePerson
+
+
+class ContractScraperService:
+    def __init__(self, timeout_ms: int = 90000) -> None:
+        self.timeout_ms = timeout_ms
+
+    def scrape_contract(self, url: str, headless: bool = True) -> ContractData:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=headless)
+            page = browser.new_page()
+            page.goto(url, wait_until="networkidle", timeout=self.timeout_ms)
+            page.wait_for_timeout(1500)
+
+            data = ContractData(
+                contract_number=self._read_contract_number(page),
+                total_value_brl=self._read_field_value(page, "Valor total"),
+                municipality=self._infer_municipality(page, url),
+                management_unit=self._read_field_value(page, "Unidade gestora:"),
+                object_description=self._read_field_value(page, "Objeto:"),
+                legal_representatives=self._read_responsibles(page, "Responsáveis Jurídicos"),
+                managers=self._read_responsibles(page, "Gestores"),
+                inspectors=self._read_responsibles(page, "Fiscais"),
+                items=self._read_items_with_pagination(page),
+            )
+
+            browser.close()
+            return data
+
+    def _read_contract_number(self, page: Page) -> str:
+        text = page.locator("text=/Contrato\s+\d+/i").first.inner_text(timeout=5000)
+        return text.strip()
+
+    def _read_field_value(self, page: Page, label: str) -> str:
+        body = page.locator("body").inner_text()
+        pattern = rf"{re.escape(label)}\s*\n([^\n]+)"
+        match = re.search(pattern, body, flags=re.IGNORECASE)
+        return match.group(1).strip() if match else ""
+
+    def _infer_municipality(self, page: Page, url: str) -> str:
+        title = page.locator("text=/Prefeitura Municipal de/i").first
+        if title.count() > 0:
+            return title.inner_text().replace("Prefeitura Municipal de", "").strip()
+        try:
+            parsed = urlparse(url)
+            fragment = parsed.fragment
+            parts = fragment.split("/")
+            return parts[1].strip().capitalize() if len(parts) > 1 else ""
+        except Exception:
+            return ""
+
+    def _read_responsibles(self, page: Page, section_title: str) -> List[ResponsiblePerson]:
+        rows = []
+        table = page.locator(f"xpath=//h3[contains(normalize-space(), '{section_title}')]/following::table[1]")
+        if table.count() == 0:
+            return rows
+
+        for tr in table.locator("tbody tr").all():
+            cols = [c.inner_text().strip() for c in tr.locator("td").all()]
+            if len(cols) >= 4:
+                rows.append(
+                    ResponsiblePerson(
+                        role=section_title,
+                        cpf=cols[0],
+                        name=cols[1],
+                        start_date=cols[2],
+                        end_date=cols[3],
+                    )
+                )
+        return rows
+
+    def _read_items_with_pagination(self, page: Page) -> List[ContractItem]:
+        items: List[ContractItem] = []
+        seen_keys: Set[str] = set()
+
+        while True:
+            current_rows = self._read_current_items_page(page)
+            for item in current_rows:
+                key = f"{item.number}-{item.description}"
+                if key not in seen_keys:
+                    seen_keys.add(key)
+                    items.append(item)
+
+            if not self._go_to_next_items_page(page):
+                break
+            page.wait_for_timeout(800)
+
+        return items
+
+    def _read_current_items_page(self, page: Page) -> List[ContractItem]:
+        table = page.locator("xpath=//h3[contains(normalize-space(), 'Itens')]/following::table[1]")
+        if table.count() == 0:
+            return []
+
+        rows: List[ContractItem] = []
+        for tr in table.locator("tbody tr").all():
+            cols = [c.inner_text().strip() for c in tr.locator("td").all()]
+            if len(cols) >= 6 and cols[0].isdigit():
+                rows.append(
+                    ContractItem(
+                        number=cols[0],
+                        description=cols[1],
+                        quantity=cols[2],
+                        unit=cols[3],
+                        unit_value_brl=cols[4],
+                        total_value_brl=cols[5],
+                    )
+                )
+        return rows
+
+    def _go_to_next_items_page(self, page: Page) -> bool:
+        candidates = [
+            "xpath=//h3[contains(normalize-space(), 'Itens')]/following::button[contains(@aria-label, 'Próxima')][1]",
+            "xpath=//h3[contains(normalize-space(), 'Itens')]/following::button[contains(@ng-click, 'next')][1]",
+            "xpath=//h3[contains(normalize-space(), 'Itens')]/following::button[.//i[contains(@class,'fa-chevron-right')]][1]",
+        ]
+
+        for selector in candidates:
+            button = page.locator(selector)
+            if button.count() == 0:
+                continue
+            class_attr = button.first.get_attribute("class") or ""
+            disabled_attr = button.first.get_attribute("disabled")
+            is_disabled = ("disabled" in class_attr.lower()) or (disabled_attr is not None)
+            if is_disabled:
+                return False
+            button.first.click()
+            return True
+
+        return False

--- a/src/contracts_scraper/utils/config.py
+++ b/src/contracts_scraper/utils/config.py
@@ -1,0 +1,15 @@
+from configparser import ConfigParser
+from pathlib import Path
+
+
+class AppConfig:
+    def __init__(self, path: str = "app.properties") -> None:
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+
+        parser = ConfigParser()
+        parser.read(path, encoding="utf-8")
+        self.contract_url = parser.get("portal", "contract_url")
+        self.headless = parser.getboolean("portal", "headless", fallback=True)
+        self.timeout_ms = parser.getint("portal", "timeout_ms", fallback=90000)


### PR DESCRIPTION
### Motivation
- Provide a maintainable Python tool to extract contract details from the e‑Pública portal (JS-rendered) including contract totals, municipality, legal representatives, managers, inspectors and items. 
- Externalize the target URL and runtime flags so the scraper can be configured without code changes.

### Description
- Added domain models for `ContractData`, `ContractItem`, and `ResponsiblePerson` in `src/contracts_scraper/domain/models.py` to represent scraped data. 
- Implemented `ContractScraperService` in `src/contracts_scraper/services/contract_scraper.py` that uses Playwright to render the page, extract fields, collect responsible people tables, and paginate the `Itens` table while deduplicating rows. 
- Added `AppConfig` in `src/contracts_scraper/utils/config.py` to read `app.properties` with `contract_url`, `headless`, and `timeout_ms` settings, and created `src/contracts_scraper/main.py` as the CLI entrypoint that prints JSON output. 
- Included `app.properties`, `requirements.txt` (Playwright), project `README.md` with usage instructions, and basic `.gitignore` entries.

### Testing
- Ran `python -m compileall src` which succeeded and confirmed modules compile without syntax errors. 
- Attempted `PYTHONPATH=src python -m contracts_scraper.main` which failed with `ModuleNotFoundError: No module named 'playwright'` because Playwright is not installed in this environment. 
- Attempted `python -m pip install -r requirements.txt` which failed in this environment due to inability to access the package index, preventing installation of Playwright and browser binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6024114e083269b4c1b2fbfc30598)